### PR TITLE
typo - semicolon after function declaration

### DIFF
--- a/js/nextras.netteForms.js
+++ b/js/nextras.netteForms.js
@@ -21,4 +21,4 @@ Nette.getValue = function(elem) {
 
 		return value.length == 0 ? null : value;
 	}
-}
+};


### PR DESCRIPTION
There should be a semicolon after function declaration. Now it makes problems, if I use Webloader, or join more javascript files.
