### PR TITLE
DateTimePicker regular expression fix

### DIFF
--- a/src/Controls/DateTimePicker.php
+++ b/src/Controls/DateTimePicker.php
@@ -31,7 +31,7 @@ class DateTimePicker extends DateTimePickerPrototype
 	protected function getDefaultParser()
 	{
 		return function($value) {
-			if (!preg_match('#^(?P<dd>\d{1,2})[. -] *(?P<mm>\d{1,2})(?:[. -] *(?P<yyyy>\d{4})?)?(?: *[ -@] *(?P<hh>\d{1,2})[:.](?P<ii>\d{1,2})(?:[:.](?P<ss>\d{1,2}))?)?$#', $value, $matches)) {
+			if (!preg_match('#^(?P<dd>\d{1,2})[. -] *(?P<mm>\d{1,2})(?:[. -] *(?P<yyyy>\d{4})?)?(?: *[ @-] *(?P<hh>\d{1,2})[:.](?P<ii>\d{1,2})(?:[:.](?P<ss>\d{1,2}))?)?$#', $value, $matches)) {
 				return NULL;
 			}
 


### PR DESCRIPTION
Hi!

I found a little bug in DateTimePicker. When I use format 'dd. mm. yyyy hh:dd', without the dash, only the second digit of hours was used. The regular expression [ -@] is a range, so it matches anything between ' ' and '@' and "eats up" the first digit.

This PR fixes that.
