### PR TITLE
Make tests run past `before_script` stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: php
 php:
-    - 5.4
-    - 5.5
     - 5.6
-    - 7
+    - 7.0
+    - 7.1
     - hhvm
-
-matrix:
-    allow_failures:
-        - php: 7
 
 script: ./tests/run.sh -s $NTESTER_FLAGS ./tests/cases
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"require": {
 		"php": ">=5.6",
 		"nette/application": "~2.4",
-		"nette/component-model": "~2.4",
+		"nette/component-model": "~2.3",
 		"nette/forms": "~2.4",
 		"nette/utils": "~2.4",
 		"latte/latte": "~2.4"


### PR DESCRIPTION
`nette/component-model` seems to currently only exist as version `2.3`. This also changes travis runners to PHP > 5.6 and disallows failure on PHP 7 as it is commonly used nowadays.