### PR TITLE
Improve compatibility with raw Nette/Forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /composer.lock
 /vendor
 /tests/php.ini
+/tests/temp
 output

--- a/src/Bridges/Latte/Macros/BS3InputMacros.php
+++ b/src/Bridges/Latte/Macros/BS3InputMacros.php
@@ -29,15 +29,19 @@ class BS3InputMacros extends BaseInputMacros
 	public static function input(Html $input, BaseControl $control, $isPart)
 	{
 		$name = $input->getName();
-		if ($name === 'select' || $name === 'textarea' || ($name === 'input' && !in_array($input->type, ['radio', 'checkbox', 'file', 'hidden', 'range', 'image', 'submit', 'reset']))) {
-			$input->addClass('form-control');
 
-		} elseif ($name === 'input' && ($input->type === 'submit' || $input->type === 'reset')) {
-			$input->setName('button');
-			$input->addHtml($input->value);
-			$input->addClass('btn');
+		if ($control->getForm()->getRenderer() instanceof Nextras\Forms\Rendering\Bs3FormRenderer) {
+			$name = $input->getName();
+			if ($name === 'select' || $name === 'textarea' || ($name === 'input' && !in_array($input->type, ['radio', 'checkbox', 'file', 'hidden', 'range', 'image', 'submit', 'reset']))) {
+				$input->addClass('form-control');
+
+			} elseif ($name === 'input' && ($input->type === 'submit' || $input->type === 'reset')) {
+				$input->setName('button');
+				$input->addHtml($input->value);
+				$input->addClass('btn');
+			}
 		}
-
+		
 		return $input;
 	}
 }

--- a/src/Bridges/Latte/Macros/BaseInputMacros.php
+++ b/src/Bridges/Latte/Macros/BaseInputMacros.php
@@ -43,7 +43,8 @@ abstract class BaseInputMacros extends MacroSet
 		}
 		$name = array_shift($words);
 		return $writer->write(
-			($name[0] === '$'
+			'$_form = isset($_form) ? $_form : $form;'
+			. ($name[0] === '$'
 				? '$_input = is_object(%0.word) ? %0.word : $_form[%0.word];'
 				: '$_input = $_form[%0.word];'
 			) . 'if ($_label = $_input->%1.raw) echo ' . $class . '::label($_label->addAttributes(%node.array), $_input, %2.var)',
@@ -78,7 +79,8 @@ abstract class BaseInputMacros extends MacroSet
 		}
 		$name = array_shift($words);
 		return $writer->write(
-			($name[0] === '$'
+			'$_form = isset($_form) ? $_form : $form;'
+			. ($name[0] === '$'
 				? '$_input = is_object(%0.word) ? %0.word : $_form[%0.word];'
 				: '$_input = $_form[%0.word];'
 			) . 'echo ' . $class . '::input($_input->%1.raw->addAttributes(%node.array), $_input, %2.var)',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,3 +4,5 @@ require __DIR__ . '/../vendor/autoload.php';
 
 date_default_timezone_set('Europe/Prague');
 Tester\Environment::setup();
+
+const TEMP_DIR = __DIR__ . DIRECTORY_SEPARATOR . 'temp';

--- a/tests/cases/BS3InputMacrosTest.phpt
+++ b/tests/cases/BS3InputMacrosTest.phpt
@@ -1,0 +1,93 @@
+<?php
+
+/** @testcase */
+
+namespace NextrasTests\Forms;
+
+use Nette;
+use Nette\Forms\Form;
+use Nextras\Forms\Bridges\Latte\Macros\BS3InputMacros;
+use Nextras\Forms\Rendering\Bs3FormRenderer;
+use Tester\Assert;
+use Tester\TestCase;
+use Latte;
+use Latte\Runtime\FilterExecutor;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+class BS3InputMactrosTest extends TestCase
+{
+	/**
+	 * @var Latte\Engine
+	 */
+	private $latte;
+	/**
+	 * @var string
+	 */
+	private $templateClassName;
+	/**
+	 * @var string
+	 */
+	private $resultTemplateFile;
+
+	public function setUp()
+	{
+		$this->latte = new Latte\Engine;
+		$this->latte->setLoader(new Latte\Loaders\StringLoader);
+		BS3InputMacros::install($this->latte->getCompiler());
+
+		@mkdir(TEMP_DIR);
+		$this->resultTemplateFile = implode(DIRECTORY_SEPARATOR, [TEMP_DIR, 'BS3InputMactrosTest.' . __FUNCTION__ . '.php']);
+
+		$codeToTest = '{input submit}';
+		$this->templateClassName = $this->latte->getTemplateClass($codeToTest);
+		file_put_contents($this->resultTemplateFile, $this->latte->compile($codeToTest));
+	}
+
+	public function testRawFormSubmit()
+	{
+		$form = new Form;
+		$form->addSubmit('submit');
+
+		Assert::same(
+			'<input type="submit" name="_submit">',
+			$this->evalTemplate($form, $this->latte, $this->templateClassName, $this->resultTemplateFile)
+		);
+	}
+
+	public function testBs3FormRendererFormSubmit()
+	{
+		$form = new Form;
+		$form->setRenderer(new Bs3FormRenderer);
+		$formSubmit = $form->addSubmit('submit');
+
+		Assert::throws(function () use ($form) {
+			$this->evalTemplate($form, $this->latte, $this->templateClassName, $this->resultTemplateFile);
+		}, Nette\InvalidArgumentException::class);
+
+		$formSubmit->caption = 'Submit label';
+
+		Assert::same(
+			'<button type="submit" name="_submit" value="Submit label" class="btn">Submit label</button>',
+			$this->evalTemplate($form, $this->latte, $this->templateClassName, $this->resultTemplateFile)
+		);
+	}
+
+	private function evalTemplate(Form $form, Latte\Engine $latte, $templateClassName, $resultFile)
+	{
+		include_once $resultFile;
+
+		/** @var Latte\Runtime\Template $tamplate */
+		$tamplate = new $templateClassName($latte, [
+			'form' => $form,
+		], new FilterExecutor, [], __FUNCTION__);
+
+		ob_start();
+		$tamplate->main();
+
+		return ob_get_clean();
+	}
+}
+
+$test = new BS3InputMactrosTest();
+$test->run();

--- a/tests/cases/BaseInputMacrosTest.phpt
+++ b/tests/cases/BaseInputMacrosTest.phpt
@@ -26,13 +26,13 @@ class BaseInputMactrosTest extends TestCase
 
 		$result = $this->extract($latte->compile('{label foo /}'));
 		Assert::same(
-			'$_input = $_form["foo"];if ($_label = $_input->getLabel()) echo NextrasTests\Forms\MockBaseInputMacros::label($_label->addAttributes([]), $_input, false);',
+			'$_form = isset($_form) ? $_form : $form;$_input = $_form["foo"];if ($_label = $_input->getLabel()) echo NextrasTests\Forms\MockBaseInputMacros::label($_label->addAttributes([]), $_input, false);',
 			$result
 		);
 
 		$result = $this->extract($latte->compile('{label foo: /}'));
 		Assert::same(
-			'$_input = $_form["foo"];if ($_label = $_input->getLabelPart("")) echo NextrasTests\Forms\MockBaseInputMacros::label($_label->addAttributes([]), $_input, true);',
+			'$_form = isset($_form) ? $_form : $form;$_input = $_form["foo"];if ($_label = $_input->getLabelPart("")) echo NextrasTests\Forms\MockBaseInputMacros::label($_label->addAttributes([]), $_input, true);',
 			$result
 		);
 	}
@@ -47,13 +47,13 @@ class BaseInputMactrosTest extends TestCase
 
 		$result = $this->extract($latte->compile('{input foo}'));
 		Assert::same(
-			'$_input = $_form["foo"];echo NextrasTests\\Forms\\MockBaseInputMacros::input($_input->getControl()->addAttributes([]), $_input, false);',
+			'$_form = isset($_form) ? $_form : $form;$_input = $_form["foo"];echo NextrasTests\\Forms\\MockBaseInputMacros::input($_input->getControl()->addAttributes([]), $_input, false);',
 			$result
 		);
 
 		$result = $this->extract($latte->compile('{input foo:}'));
 		Assert::same(
-			'$_input = $_form["foo"];echo NextrasTests\Forms\MockBaseInputMacros::input($_input->getControlPart("")->addAttributes([]), $_input, true);',
+			'$_form = isset($_form) ? $_form : $form;$_input = $_form["foo"];echo NextrasTests\Forms\MockBaseInputMacros::input($_input->getControlPart("")->addAttributes([]), $_input, true);',
 			$result
 		);
 	}


### PR DESCRIPTION
Hi,

I found some problems with co-existence `Nextras/Forms` and raw `Nette/Forms` (without `Bs3FormRenderer`). I think `BS3InputMacros::input` macro could be used only for forms with `Bs3FormRenderer` (or ext).

Second change in `BS3InputMacros::input` is for support render own form-part using latte include 

Use case: pass `$form` into included block, and Nette 2.4 do not allow pass/redefine `$_form` - because it is deprecated.
