### PR TITLE
Fixed: better type attribute change and previously half-baked date recognizer

### DIFF
--- a/js/nextras.datetimepicker.init.js
+++ b/js/nextras.datetimepicker.init.js
@@ -7,10 +7,17 @@
  */
 
 jQuery(function($) {
+	$('input[type="date"]:not(.date)').addClass('date');
+	$('input[type="datetime-local"]:not(.datetime-local)').addClass('datetime-local');
+
 	$('input.date, input.datetime-local').each(function(i, el) {
 		el = $(el);
 		var isDate = el.is('.date') || el.is('[type="date"]');
-		el.first().type = 'text';
+
+		var value = el.val();
+		el.get(0).type = 'text';
+		el.val(value); // MS Edge workaround
+
 		el.datetimepicker({
 			startDate: el.attr('min'),
 			endDate: el.attr('max'),


### PR DESCRIPTION
Sorry, previous PR #45 did not function as much as I expected (with respect of reported issue to jquery library: https://github.com/jquery/jquery/issues/3633) and #46 was only half-baked, so it was completely rewritten to handle attribute type="(date|datetime-local)" only (without attribute class="(date|datetime-local)").