### PR TITLE
Enable Nette v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-    - 5.6
-    - 7.0
     - 7.1
+    - 7.2
+    - 7.3
 
 script: ./tests/run.sh -s $NTESTER_FLAGS ./tests/cases
 

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6",
-		"nette/application": "~2.4",
-		"nette/component-model": "~2.3",
-		"nette/forms": "~2.4",
-		"nette/utils": "~2.4",
-		"latte/latte": "~2.4"
+		"php": ">=7.1",
+		"nette/application": "~2.4|^3.0",
+		"nette/component-model": "~2.3|^3.0",
+		"nette/forms": "~2.4|^3.0",
+		"nette/utils": "~2.4|^3.0",
+		"latte/latte": "~2.4|^2.6"
 	},
 	"require-dev": {
 		"nette/tester": "~1.4"

--- a/src/Controls/DateTimePickerPrototype.php
+++ b/src/Controls/DateTimePickerPrototype.php
@@ -42,7 +42,7 @@ abstract class DateTimePickerPrototype extends TextBase
 	 *
 	 * @return Html
 	 */
-	public function getControl()
+	public function getControl() : Html
 	{
 		$control = parent::getControl();
 		$control->type = $this->htmlType;

--- a/src/Controls/Typeahead.php
+++ b/src/Controls/Typeahead.php
@@ -11,6 +11,7 @@ namespace Nextras\Forms\Controls;
 
 use Nette;
 use Nette\Forms;
+use Nette\Utils\Html;
 use Nextras\Forms\Controls\Fragments\ComponentControlTrait;
 
 
@@ -34,7 +35,7 @@ class Typeahead extends Forms\Controls\TextInput implements Nette\Application\UI
 	}
 
 
-	public function getControl()
+	public function getControl() : Html
 	{
 		$control = parent::getControl();
 		$control->addClass('typeahead');

--- a/src/Rendering/Bs3FormRenderer.php
+++ b/src/Rendering/Bs3FormRenderer.php
@@ -13,6 +13,7 @@ use Nette;
 use Nette\Forms\Controls;
 use Nette\Forms\Form;
 use Nette\Forms\Rendering\DefaultFormRenderer;
+use Nette\Utils\Html;
 
 
 /**
@@ -41,56 +42,56 @@ class Bs3FormRenderer extends DefaultFormRenderer
 	}
 
 
-	public function renderBegin()
+	public function renderBegin(): string
 	{
 		$this->controlsInit();
 		return parent::renderBegin();
 	}
 
 
-	public function renderEnd()
+	public function renderEnd(): string
 	{
 		$this->controlsInit();
 		return parent::renderEnd();
 	}
 
 
-	public function renderBody()
+	public function renderBody(): string
 	{
 		$this->controlsInit();
 		return parent::renderBody();
 	}
 
 
-	public function renderControls($parent)
+	public function renderControls($parent): string
 	{
 		$this->controlsInit();
 		return parent::renderControls($parent);
 	}
 
 
-	public function renderPair(Nette\Forms\IControl $control)
+	public function renderPair(Nette\Forms\IControl $control): string
 	{
 		$this->controlsInit();
 		return parent::renderPair($control);
 	}
 
 
-	public function renderPairMulti(array $controls)
+	public function renderPairMulti(array $controls): string
 	{
 		$this->controlsInit();
 		return parent::renderPairMulti($controls);
 	}
 
 
-	public function renderLabel(Nette\Forms\IControl $control)
+	public function renderLabel(Nette\Forms\IControl $control): Html
 	{
 		$this->controlsInit();
 		return parent::renderLabel($control);
 	}
 
 
-	public function renderControl(Nette\Forms\IControl $control)
+	public function renderControl(Nette\Forms\IControl $control): Html
 	{
 		$this->controlsInit();
 		return parent::renderControl($control);

--- a/src/Rendering/Bs4FormRenderer.php
+++ b/src/Rendering/Bs4FormRenderer.php
@@ -6,6 +6,7 @@ use Nette;
 use Nette\Forms\Controls;
 use Nette\Forms\Form;
 use Nette\Forms\Rendering\DefaultFormRenderer;
+use Nette\Utils\Html;
 
 /**
  * FormRenderer for Bootstrap 4 framework.
@@ -51,63 +52,63 @@ class Bs4FormRenderer extends DefaultFormRenderer
 	}
 
 
-	public function renderBegin()
+	public function renderBegin(): string
 	{
 		$this->controlsInit();
 		return parent::renderBegin();
 	}
 
 
-	public function renderEnd()
+	public function renderEnd(): string
 	{
 		$this->controlsInit();
 		return parent::renderEnd();
 	}
 
 
-	public function renderBody()
+	public function renderBody(): string
 	{
 		$this->controlsInit();
 		return parent::renderBody();
 	}
 
 
-	public function renderControls($parent)
+	public function renderControls($parent): string
 	{
 		$this->controlsInit();
 		return parent::renderControls($parent);
 	}
 
 
-	public function renderPair(Nette\Forms\IControl $control)
+	public function renderPair(Nette\Forms\IControl $control): string
 	{
 		$this->controlsInit();
 		return parent::renderPair($control);
 	}
 
 
-	public function renderPairMulti(array $controls)
+	public function renderPairMulti(array $controls): string
 	{
 		$this->controlsInit();
 		return parent::renderPairMulti($controls);
 	}
 
 
-	public function renderLabel(Nette\Forms\IControl $control)
+	public function renderLabel(Nette\Forms\IControl $control): Html
 	{
 		$this->controlsInit();
 		return parent::renderLabel($control);
 	}
 
 
-	public function renderControl(Nette\Forms\IControl $control)
+	public function renderControl(Nette\Forms\IControl $control): Html
 	{
 		$this->controlsInit();
 		return parent::renderControl($control);
 	}
 
 
-	private function controlsInit()
+	private function controlsInit(): void
 	{
 		if ($this->controlsInit) {
 			return;


### PR DESCRIPTION
BC Break? Maybe

It relaxes dependencies to enable Nette v3 dependencies. But also introduce strict return types into Renderer (DefaultFormRenderer introduce them). Therefore minimal runtime is set to 7.1.